### PR TITLE
Return polling promise

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -108,9 +108,9 @@ TelegramBot.prototype._processUpdates = function (updates) {
 
 TelegramBot.prototype._polling = function (timeout) {
   var self = this;
-  this.getUpdates(timeout).then(function (data) {
+  return this.getUpdates(timeout).then(function (data) {
     self._processUpdates(data);
-    self._polling(timeout);
+    return self._polling(timeout);
   });
 };
 


### PR DESCRIPTION
This is useful to be able to catch exception if something bad happens inside the polling (which causes the polling to stop). That way the developer can decide what to do in case of an error.

This happened to me, telegram returned an error and the polling stopped.